### PR TITLE
(TK-127) Rename to puppetlabs-hocon

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,36 +1,36 @@
-#CONF file
+#HOCON file
 
 ####Table of Contents
 
 1. [Overview](#overview)
 2. [Module Description - What the module does and why it is useful](#module-description)
-3. [Setup - The basics of getting started with conffile module](#setup)
+3. [Setup - The basics of getting started with the hocon module](#setup)
     * [Setup requirements](#setup-requirements)
-    * [Beginning with conffile](#beginning-with-conffile)
+    * [Beginning with hocon](#beginning-with-hocon)
 4. [Usage - Configuration options and additional functionality](#usage)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 6. [Development - Guide for contributing to the module](#development)
 
 ##Overview 
 
-This module adds resource types to manage settings in CONF-style configuration files.
+This module adds resource types to manage settings in HOCON-style configuration files.
 
 ##Module Description
 
-The conffile module adds a resource type so that you can use Puppet to manage settings in HOCON configuration files.
+The hocon module adds a resource type so that you can use Puppet to manage settings in HOCON configuration files.
 
 ##Setup
 
-##Beginning with conffile
+##Beginning with hocon
 
-To manage a conf file, add the resource type `conf_setting` to a class.
+To manage a HOCON file, add the resource type `hocon_setting` to a class.
 
 ##Usage
 
-Manage individual settings in CONF files by adding the `conf_setting` resource type to a class. For example:
+Manage individual settings in HOCON files by adding the `hocon_setting` resource type to a class. For example:
 
 ```
-conf_setting { "sample setting":
+hocon_setting { "sample setting":
   ensure  => present,
   path    => '/tmp/foo.conf',
   setting => 'foosetting',
@@ -48,7 +48,7 @@ foo {
     }
 }
 
-conf_setting {'sample nested setting':
+hocon_setting {'sample nested setting':
   ensure  => present,
   path => '/tmp/foo.conf',
   setting => 'foo.bar.barsetting',
@@ -58,7 +58,7 @@ conf_setting {'sample nested setting':
 
 ##Reference
 
-###Type: conf_setting
+###Type: hocon_setting
 
 #### Parameters
 
@@ -66,16 +66,16 @@ conf_setting {'sample nested setting':
 
 * `name`: An arbitrary name used as the identity of the resource.
 
-* `path`: The CONF file in which Puppet will ensure the specified setting.
+* `path`: The HOCON file in which Puppet will ensure the specified setting.
 
-* `provider`: The specific backend to use for this `conf_setting` resource. You will seldom need to specify this --- Puppet will usually discover the appropriate provider for your platform. The only available provider for `conf_setting` is ruby.
+* `provider`: The specific backend to use for this `hocon_setting` resource. You will seldom need to specify this --- Puppet will usually discover the appropriate provider for your platform. The only available provider for `hocon_setting` is ruby.
 
-* `setting`: The name of the CONF file setting to be defined. This can be a top-level setting or a setting nested
+* `setting`: The name of the HOCON file setting to be defined. This can be a top-level setting or a setting nested
   within another setting. To define a nested setting, give the full path to that setting with each level separated
   by a `.` So, to define a setting `foosetting` nested within a setting called `foo` contained on the top level,
   the `setting` parameter would be set to `foo.foosetting`.
 
-* `value`: The value of the CONF file setting to be defined.
+* `value`: The value of the HOCON file setting to be defined.
 
 ##Development
  
@@ -87,4 +87,4 @@ You can read the complete module contribution guide on the [Puppet Labs wiki](ht
 
 ##Contributors
 
-The list of contributors can be found at: [https://github.com/puppetlabs/puppetlabs-conffile/graphs/contributors/contributors](https://github.com/puppetlabs/puppetlabs-conffile/graphs/contributors/contributors).
+The list of contributors can be found at: [https://github.com/puppetlabs/puppetlabs-hocon/graphs/contributors/contributors](https://github.com/puppetlabs/puppetlabs-hocon/graphs/contributors/contributors).

--- a/lib/puppet/provider/hocon_setting/ruby.rb
+++ b/lib/puppet/provider/hocon_setting/ruby.rb
@@ -6,7 +6,7 @@ end
 
 require File.expand_path('../../../util/config_saver', __FILE__)
 
-Puppet::Type.type(:conf_setting).provide(:ruby) do
+Puppet::Type.type(:hocon_setting).provide(:ruby) do
   def self.namevar(section_name, setting)
     "#{setting}"
   end

--- a/lib/puppet/type/hocon_setting.rb
+++ b/lib/puppet/type/hocon_setting.rb
@@ -1,4 +1,4 @@
-Puppet::Type.newtype(:conf_setting) do
+Puppet::Type.newtype(:hocon_setting) do
 
   ensurable do
     defaultvalues

--- a/metadata.json
+++ b/metadata.json
@@ -1,11 +1,11 @@
 {
-    "name": "puppetlabs-conffile",
+    "name": "puppetlabs-hocon",
     "version": "0.1.1",
-    "source": "https://github.com/puppetlabs/puppetlabs-conffile",
+    "source": "https://github.com/puppetlabs/puppetlabs-hocon",
     "author": "Puppet Labs",
     "license": "Apache-2.0",
-    "project_page": "https://github.com/puppetlabs/puppetlabs-conffile",
-    "summary": "Resource types for managing settings in CONF files",
+    "project_page": "https://github.com/puppetlabs/puppetlabs-hocon",
+    "summary": "Resource types for managing settings in HOCON files",
     "operatingsystem_support": [
       {
         "operatingsystem": "CentOS",

--- a/spec/acceptance/conf_setting_spec.rb
+++ b/spec/acceptance/conf_setting_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 tmpdir = default.tmpdir('tmp')
 
-describe 'conf_setting resource' do
+describe 'hocon_setting resource' do
   after :all do
     shell("rm #{tmpdir}/*.conf", :acceptable_exit_codes => [0,1,2])
   end
@@ -51,15 +51,15 @@ describe 'conf_setting resource' do
   describe 'ensure parameter' do
     context '=> present for top-level and nested' do
       pp = <<-EOS
-      conf_setting { 'ensure => present for section':
+      hocon_setting { 'ensure => present for section':
         ensure  => present,
-        path    => "#{tmpdir}/conf_setting.conf",
+        path    => "#{tmpdir}/hocon_setting.conf",
         setting => 'one.two',
         value   => 'three',
       }
-      conf_setting { 'ensure => present for top level':
+      hocon_setting { 'ensure => present for top level':
         ensure  => present,
-        path    => "#{tmpdir}/conf_setting.conf",
+        path    => "#{tmpdir}/hocon_setting.conf",
         setting => 'four',
         value   => 'five',
       }
@@ -70,7 +70,7 @@ describe 'conf_setting resource' do
         apply_manifest(pp, :catch_changes => true)
       end
 
-      describe file("#{tmpdir}/conf_setting.conf") do
+      describe file("#{tmpdir}/hocon_setting.conf") do
         it { should be_file }
         #XXX Solaris 10 doesn't support multi-line grep
         it("should contain one {\n    two=three\n}\nfour=five", :unless => fact('osfamily') == 'Solaris') {
@@ -82,16 +82,16 @@ describe 'conf_setting resource' do
     context '=> absent for key/value' do
       before :all do
         if fact('osfamily') == 'Darwin'
-          shell("echo \"one {\n    two=three\n}\nfour=five\" > #{tmpdir}/conf_setting.conf")
+          shell("echo \"one {\n    two=three\n}\nfour=five\" > #{tmpdir}/hocon_setting.conf")
         else
-          shell("echo -e \"one {\n    two=three\n}\nfour=five\" > #{tmpdir}/conf_setting.conf")
+          shell("echo -e \"one {\n    two=three\n}\nfour=five\" > #{tmpdir}/hocon_setting.conf")
         end
       end
 
       pp = <<-EOS
-      conf_setting { 'ensure => absent for key/value':
+      hocon_setting { 'ensure => absent for key/value':
         ensure  => absent,
-        path    => "#{tmpdir}/conf_setting.conf",
+        path    => "#{tmpdir}/hocon_setting.conf",
         setting => 'one.two',
         value   => 'three',
       }
@@ -102,7 +102,7 @@ describe 'conf_setting resource' do
         apply_manifest(pp, :catch_changes  => true)
       end
 
-      describe file("#{tmpdir}/conf_setting.conf") do
+      describe file("#{tmpdir}/hocon_setting.conf") do
         it { should be_file }
         it { should contain('four=five') }
         it { should_not contain("two=three") }
@@ -112,20 +112,20 @@ describe 'conf_setting resource' do
     context '=> absent for top-level settings' do
       before :all do
         if fact('osfamily') == 'Darwin'
-          shell("echo \"one {\n    two=three\n}\nfour=five\" > #{tmpdir}/conf_setting.conf")
+          shell("echo \"one {\n    two=three\n}\nfour=five\" > #{tmpdir}/hocon_setting.conf")
         else
-          shell("echo -e \"one {\n    two=three\n}\nfour=five\" > #{tmpdir}/conf_setting.conf")
+          shell("echo -e \"one {\n    two=three\n}\nfour=five\" > #{tmpdir}/hocon_setting.conf")
         end
       end
       after :all do
-        shell("cat #{tmpdir}/conf_setting.conf", :acceptable_exit_codes => [0,1,2])
-        shell("rm #{tmpdir}/conf_setting.conf", :acceptable_exit_codes => [0,1,2])
+        shell("cat #{tmpdir}/hocon_setting.conf", :acceptable_exit_codes => [0,1,2])
+        shell("rm #{tmpdir}/hocon_setting.conf", :acceptable_exit_codes => [0,1,2])
       end
 
       pp = <<-EOS
-      conf_setting { 'ensure => absent for top-level':
+      hocon_setting { 'ensure => absent for top-level':
         ensure  => absent,
-        path    => "#{tmpdir}/conf_setting.conf",
+        path    => "#{tmpdir}/hocon_setting.conf",
         setting => 'four',
         value   => 'five',
       }
@@ -136,7 +136,7 @@ describe 'conf_setting resource' do
         apply_manifest(pp, :catch_changes  => true)
       end
 
-      describe file("#{tmpdir}/conf_setting.conf") do
+      describe file("#{tmpdir}/hocon_setting.conf") do
         it { should be_file }
         it { should_not contain('four=five') }
         it { should contain("one {\n    two=three\n}") }
@@ -152,14 +152,14 @@ describe 'conf_setting resource' do
     }.each do |parameter_list, content|
       context parameter_list do
         pp = <<-EOS
-        conf_setting { "#{parameter_list}":
+        hocon_setting { "#{parameter_list}":
           ensure  => present,
-          path    => "#{tmpdir}/conf_setting.conf",
+          path    => "#{tmpdir}/hocon_setting.conf",
           #{parameter_list}
         }
         EOS
 
-        it_behaves_like 'has_content', "#{tmpdir}/conf_setting.conf", pp, content
+        it_behaves_like 'has_content', "#{tmpdir}/hocon_setting.conf", pp, content
       end
     end
 
@@ -170,14 +170,14 @@ describe 'conf_setting resource' do
     }.each do |parameter_list, error|
       context parameter_list, :pending => 'no error checking yet' do
         pp = <<-EOS
-        conf_setting { "#{parameter_list}":
+        hocon_setting { "#{parameter_list}":
           ensure  => present,
-          path    => "#{tmpdir}/conf_setting.conf",
+          path    => "#{tmpdir}/hocon_setting.conf",
           #{parameter_list}
         }
         EOS
 
-        it_behaves_like 'has_error', "#{tmpdir}/conf_setting.conf", pp, error
+        it_behaves_like 'has_error', "#{tmpdir}/hocon_setting.conf", pp, error
       end
     end
   end
@@ -190,7 +190,7 @@ describe 'conf_setting resource' do
     ].each do |path|
       context "path => #{path}" do
         pp = <<-EOS
-        conf_setting { 'path => #{path}':
+        hocon_setting { 'path => #{path}':
           ensure  => present,
           setting => 'one.two',
           value   => 'three',
@@ -204,7 +204,7 @@ describe 'conf_setting resource' do
 
     context "path => foo" do
       pp = <<-EOS
-        conf_setting { 'path => foo':
+        hocon_setting { 'path => foo':
           ensure     => present,
           setting    => 'one.two',
           value      => 'three',

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -29,7 +29,7 @@ RSpec.configure do |c|
     # Install module and dependencies
     hosts.each do |host|
       if host['platform'] !~ /windows/i
-        copy_root_module_to(host, :source => proj_root, :module_name => 'conffile')
+        copy_root_module_to(host, :source => proj_root, :module_name => 'hocon')
       end
     end
     hosts.each do |host|

--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -1,15 +1,15 @@
 require 'spec_helper'
 require 'puppet'
 
-provider_class = Puppet::Type.type(:conf_setting).provider(:ruby)
+provider_class = Puppet::Type.type(:hocon_setting).provider(:ruby)
 describe provider_class do
   include PuppetlabsSpec::Files
 
-  let(:tmpfile) { tmpfilename("conf_setting_test.conf") }
-  let(:emptyfile) { tmpfilename("conf_setting_test_empty.conf") }
+  let(:tmpfile) { tmpfilename("hocon_setting_test.conf") }
+  let(:emptyfile) { tmpfilename("hocon_setting_test_empty.conf") }
 
   let(:common_params) { {
-      :title    => 'conf_setting_ensure_present_test',
+      :title    => 'hocon_setting_ensure_present_test',
       :path     => tmpfile,
   } }
 
@@ -57,7 +57,7 @@ foo: bar
     }
 
     it "should add a missing setting to the correct map" do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
           :setting => 'test_key_1.yahoo', :value => 'yippee'))
       provider = described_class.new(resource)
       provider.exists?.should be false
@@ -87,7 +87,7 @@ foo=bar
     end
 
     it "should modify an existing setting with a different value" do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
            :setting => 'test_key_2.baz', :value => 'bazvalue2'))
       provider = described_class.new(resource)
       provider.exists?.should be true
@@ -116,7 +116,7 @@ foo=bar
     end
 
     it "should be able to handle settings with non alphanumbering settings " do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
            :setting => 'test_key_2.url', :value => 'http://192.168.0.1:8080'))
       provider = described_class.new(resource)
       provider.exists?.should be true
@@ -147,14 +147,14 @@ foo=bar
     end
 
     it "should recognize an existing setting with the specified value" do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
            :setting => 'test_key_2.baz', :value => 'bazvalue'))
       provider = described_class.new(resource)
       provider.exists?.should be true
     end
 
     it "should add a new map if the path contains a non-existent map" do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
           :setting => 'test_key_4.huzzah', :value => 'shazaam'))
       provider = described_class.new(resource)
       provider.exists?.should be false
@@ -186,7 +186,7 @@ foo=bar
     end
 
     it "should add a new map if no maps exists" do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
           :setting => 'test_key_1.setting1', :value => 'hellowworld', :path => emptyfile))
       provider = described_class.new(resource)
       provider.exists?.should be false
@@ -199,7 +199,7 @@ foo=bar
     end
 
     it "should be able to handle variables of any type" do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
           :setting => 'test_key_1.master', :value => true))
       provider = described_class.new(resource)
       provider.exists?.should be true
@@ -222,7 +222,7 @@ foo=blah
 
 
     it "should add a missing setting if it doesn't exist" do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
           :setting => 'bar', :value => 'yippee'))
       provider = described_class.new(resource)
       provider.exists?.should be false
@@ -241,7 +241,7 @@ bar=yippee
 
     # TODO: Investigate removal of comment
     it "should modify an existing setting with a different value" do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
            :setting => 'foo', :value => 'yippee'))
       provider = described_class.new(resource)
       provider.exists?.should be true
@@ -258,7 +258,7 @@ foo=yippee
     end
 
     it "should recognize an existing setting with the specified value" do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
            :setting => 'foo', :value => 'blah'))
       provider = described_class.new(resource)
       provider.exists?.should be true
@@ -275,7 +275,7 @@ foo=yippee
     }
 
     it "should be able to add a setting to the top-level map" do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
            :setting => 'foo', :value => 'yippee'))
       provider = described_class.new(resource)
       provider.exists?.should be false
@@ -311,7 +311,7 @@ EOS
     }
 
     it "should remove a setting that exists" do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
       :setting => 'test_key_1.foo', :ensure => 'absent'))
       provider = described_class.new(resource)
       provider.exists?.should be true
@@ -334,7 +334,7 @@ EOS
     end
 
     it "should do nothing for a setting that does not exist" do
-      resource = Puppet::Type::Conf_setting.new(common_params.merge(
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
                                                    :setting => 'test_key_3.foo', :ensure => 'absent'))
       provider = described_class.new(resource)
       provider.exists?.should be false

--- a/tests/hocon_setting.pp
+++ b/tests/hocon_setting.pp
@@ -1,21 +1,21 @@
-conf_setting { 'sample setting':
+hocon_setting { 'sample setting':
   ensure  => present,
   path    => '/tmp/foo.conf',
   setting => 'foo.foosetting',
   value   => 'FOO!',
 }
 
-conf_setting { 'sample setting2':
+hocon_setting { 'sample setting2':
   ensure            => present,
   path              => '/tmp/foo.conf',
   setting           => 'bar.barsetting',
   value             => 'BAR!',
-  require           => Conf_setting['sample setting'],
+  require           => Hocon_setting['sample setting'],
 }
 
-conf_setting { 'sample setting3':
+hocon_setting { 'sample setting3':
   ensure  => absent,
   path    => '/tmp/foo.conf',
   setting => 'bar.bazsetting',
-  require => Conf_setting['sample setting2'],
+  require => Hocon_setting['sample setting2'],
 }


### PR DESCRIPTION
Rename the puppetlabs-conffile module to puppetlabs-hocon. Rename
the conf_setting type to hocon_setting.

Once this is merged this repo should be renamed to puppetlabs-hocon.

@reidmv Here's the rename you were asking about.
