### PR TITLE
(TK-191) Use ConfigDocument API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ spec/fixtures/
 .vagrant/
 .bundle/
 coverage/
+log/

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :test do
   gem 'rake',                    :require => false
-  gem 'rspec', '~> 2.11',        :require => false
+  gem 'rspec',                   :require => false
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'serverspec',              :require => false
@@ -25,6 +25,6 @@ else
   gem 'puppet', :require => false
 end
 
-gem 'hocon', '~> 0.0.6',       :require => false
+gem 'hocon', '~> 0.1.0',       :require => false
 
 # vim:ft=ruby

--- a/lib/puppet/provider/hocon_setting/ruby.rb
+++ b/lib/puppet/provider/hocon_setting/ruby.rb
@@ -1,6 +1,7 @@
 require 'puppet/util/feature'
 if Puppet.features.hocon?
   require 'hocon/config_factory'
+  require 'hocon/parser/config_document_factory'
   require 'hocon/config_value_factory'
 end
 
@@ -12,29 +13,29 @@ Puppet::Type.type(:hocon_setting).provide(:ruby) do
   end
 
   def exists?
-    conf_file.has_path(setting)
+    conf_file.has_value?(setting)
   end
 
   def create
     value = Hocon::ConfigValueFactory.from_any_ref(resource[:value], nil)
-    conf_file_modified = conf_file.with_value(setting, value)
+    conf_file_modified = conf_file.set_config_value(setting, value)
     Puppet::Util::ConfigSaver.save(resource[:path], conf_file_modified)
     @conf_file = nil
   end
 
   def destroy
-    conf_file_modified = conf_file.without_path(setting)
+    conf_file_modified = conf_file.remove_value(setting)
     Puppet::Util::ConfigSaver.save(resource[:path], conf_file_modified)
     @conf_file = nil
   end
 
   def value
-    conf_file.get_value(setting).unwrapped
+    conf_object.get_value(setting).unwrapped
   end
 
   def value=(value)
     value = Hocon::ConfigValueFactory.from_any_ref(resource[:value], nil)
-    conf_file_modified = conf_file.with_value(setting, value)
+    conf_file_modified = conf_file.set_config_value(setting, value)
     Puppet::Util::ConfigSaver.save(resource[:path], conf_file_modified)
     @conf_file = nil
   end
@@ -52,7 +53,14 @@ Puppet::Type.type(:hocon_setting).provide(:ruby) do
     if @conf_file.nil? && (not File.exist?(file_path))
       File.new(file_path, "w")
     end
-    @conf_file ||= Hocon::ConfigFactory.parse_file(file_path)
+    @conf_file ||= Hocon::Parser::ConfigDocumentFactory.parse_file(file_path)
+  end
+
+  def conf_object
+    if @conf_file.nil? && (not File.exist?(file_path))
+      File.new(file_path, "w")
+    end
+    Hocon::ConfigFactory.parse_file(file_path)
   end
 
 end

--- a/lib/puppet/util/config_saver.rb
+++ b/lib/puppet/util/config_saver.rb
@@ -6,7 +6,6 @@ module Puppet
     class ConfigSaver
       def self.save(path, conf)
         File.open(path, 'w+') do |fh|
-          #config_string = conf.root.render(Hocon::ConfigRenderOptions.new(false, true, true, false))
           config_string = conf.render
           fh.puts(config_string)
         end

--- a/lib/puppet/util/config_saver.rb
+++ b/lib/puppet/util/config_saver.rb
@@ -6,7 +6,8 @@ module Puppet
     class ConfigSaver
       def self.save(path, conf)
         File.open(path, 'w+') do |fh|
-          config_string = conf.root.render(Hocon::ConfigRenderOptions.new(false, true, true, false))
+          #config_string = conf.root.render(Hocon::ConfigRenderOptions.new(false, true, true, false))
+          config_string = conf.render
           fh.puts(config_string)
         end
       end

--- a/spec/acceptance/conf_setting_spec.rb
+++ b/spec/acceptance/conf_setting_spec.rb
@@ -148,7 +148,7 @@ describe 'hocon_setting resource' do
     {
       "setting => 'test.foo', value => 'bar',"   => "test {\n    foo = bar\n}",
       "setting => 'more.baz', value => 'quux',"  => "more {\n    baz = quux\n}",
-      "setting => 'top', value => 'level',"      => "top=level",
+      "setting => 'top', value => 'level',"      => "top : \"level\"",
     }.each do |parameter_list, content|
       context parameter_list do
         pp = <<-EOS

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,10 +1,10 @@
 HOSTS:
-  centos-64-x64:
+  debian-73-x64:
     roles:
       - master
-    platform: el-6-x86_64
-    box : centos-64-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box
+    platform: debian-7-amd64
+    box : debian-73-x64-virtualbox-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/debian-73-x64-virtualbox-nocm.box
     hypervisor : vagrant
 CONFIG:
   type: git

--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -15,7 +15,7 @@ describe provider_class do
 
   def validate_file(expected_content,tmpfile = tmpfile)
     tmpcontent = File.read(tmpfile)
-    File.read(tmpfile).should == expected_content
+    expect(File.read(tmpfile)).to eq(expected_content)
   end
 
 
@@ -60,28 +60,33 @@ foo: bar
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
           :setting => 'test_key_1.yahoo', :value => 'yippee'))
       provider = described_class.new(resource)
-      provider.exists?.should be false
+      expect(provider.exists?).to be false
       provider.create
-      validate_file(<<-EOS
+      validate_file(
+          <<-EOS
 # This is a comment
-"test_key_1" {
-    # This is also a comment
-    foo=foovalue
-    bar=barvalue
-    master=true
-    yahoo=yippee
+test_key_1: {
+// This is also a comment
+  foo: foovalue
+
+  bar: barvalue
+  master: true
+  yahoo : "yippee"
 }
-"test_key_2" {
-    foo=foovalue2
-    baz=bazvalue
-    url="http://192.168.1.1:8080"
+
+test_key_2: {
+
+  foo: foovalue2
+  baz: bazvalue
+  url: "http://192.168.1.1:8080"
 }
-"test_key:3" {
-    foo=bar
+
+"test_key:3": {
+  foo: bar
 }
-# another comment
-# yet another comment
-foo=bar
+    #another comment
+// yet another comment
+foo: bar
       EOS
 )
     end
@@ -90,27 +95,32 @@ foo=bar
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
            :setting => 'test_key_2.baz', :value => 'bazvalue2'))
       provider = described_class.new(resource)
-      provider.exists?.should be true
+      expect(provider.exists?).to be true
       provider.value=('bazvalue2')
-      validate_file(<<-EOS
+      validate_file(
+          <<-EOS
 # This is a comment
-"test_key_1" {
-    # This is also a comment
-    foo=foovalue
-    bar=barvalue
-    master=true
+test_key_1: {
+// This is also a comment
+  foo: foovalue
+
+  bar: barvalue
+  master: true
 }
-"test_key_2" {
-    foo=foovalue2
-    baz=bazvalue2
-    url="http://192.168.1.1:8080"
+
+test_key_2: {
+
+  foo: foovalue2
+  baz: "bazvalue2"
+  url: "http://192.168.1.1:8080"
 }
-"test_key:3" {
-    foo=bar
+
+"test_key:3": {
+  foo: bar
 }
-# another comment
-# yet another comment
-foo=bar
+    #another comment
+// yet another comment
+foo: bar
       EOS
       )
     end
@@ -119,29 +129,34 @@ foo=bar
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
            :setting => 'test_key_2.url', :value => 'http://192.168.0.1:8080'))
       provider = described_class.new(resource)
-      provider.exists?.should be true
-      provider.value.should == 'http://192.168.1.1:8080'
+      expect(provider.exists?).to be true
+      expect(provider.value).to eq('http://192.168.1.1:8080')
       provider.value=('http://192.168.0.1:8080')
 
-      validate_file(<<-EOS
+      validate_file(
+          <<-EOS
 # This is a comment
-"test_key_1" {
-    # This is also a comment
-    foo=foovalue
-    bar=barvalue
-    master=true
+test_key_1: {
+// This is also a comment
+  foo: foovalue
+
+  bar: barvalue
+  master: true
 }
-"test_key_2" {
-    foo=foovalue2
-    baz=bazvalue
-    url="http://192.168.0.1:8080"
+
+test_key_2: {
+
+  foo: foovalue2
+  baz: bazvalue
+  url: "http://192.168.0.1:8080"
 }
-"test_key:3" {
-    foo=bar
+
+"test_key:3": {
+  foo: bar
 }
-# another comment
-# yet another comment
-foo=bar
+    #another comment
+// yet another comment
+foo: bar
       EOS
       )
     end
@@ -150,60 +165,59 @@ foo=bar
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
            :setting => 'test_key_2.baz', :value => 'bazvalue'))
       provider = described_class.new(resource)
-      provider.exists?.should be true
+      expect(provider.exists?).to be true
     end
 
     it "should add a new map if the path contains a non-existent map" do
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
           :setting => 'test_key_4.huzzah', :value => 'shazaam'))
       provider = described_class.new(resource)
-      provider.exists?.should be false
+      expect(provider.exists?).to be false
       provider.create
-      validate_file(<<-EOS
+      validate_file(
+          <<-EOS
 # This is a comment
-"test_key_1" {
-    # This is also a comment
-    foo=foovalue
-    bar=barvalue
-    master=true
+test_key_1: {
+// This is also a comment
+  foo: foovalue
+
+  bar: barvalue
+  master: true
 }
-"test_key_2" {
-    foo=foovalue2
-    baz=bazvalue
-    url="http://192.168.1.1:8080"
+
+test_key_2: {
+
+  foo: foovalue2
+  baz: bazvalue
+  url: "http://192.168.1.1:8080"
 }
-"test_key:3" {
-    foo=bar
+
+"test_key:3": {
+  foo: bar
 }
-# another comment
-# yet another comment
-foo=bar
-"test_key_4" {
-    huzzah=shazaam
-}
+    #another comment
+// yet another comment
+foo: bar
+test_key_4 : { huzzah : "shazaam" }
       EOS
       )
     end
 
     it "should add a new map if no maps exists" do
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
-          :setting => 'test_key_1.setting1', :value => 'hellowworld', :path => emptyfile))
+          :setting => 'test_key_1.setting1', :value => 'helloworld', :path => emptyfile))
       provider = described_class.new(resource)
-      provider.exists?.should be false
+      expect(provider.exists?).to be false
       provider.create
-      validate_file(
-"\"test_key_1\" {
-    setting1=hellowworld
-}
-", emptyfile)
+      validate_file(" test_key_1 : { setting1 : \"helloworld\" }\n", emptyfile)
     end
 
     it "should be able to handle variables of any type" do
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
           :setting => 'test_key_1.master', :value => true))
       provider = described_class.new(resource)
-      provider.exists?.should be true
-      provider.value.should eql(true)
+      expect(provider.exists?).to be true
+      expect(provider.value).to eql(true)
     end
 
   end
@@ -225,7 +239,7 @@ foo=blah
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
           :setting => 'bar', :value => 'yippee'))
       provider = described_class.new(resource)
-      provider.exists?.should be false
+      expect(provider.exists?).to be false
       provider.create
       validate_file(<<-EOS
 # This is a comment
@@ -234,7 +248,7 @@ foo=blah
     # yet another comment
     foo="http://192.168.1.1:8080"
 }
-bar=yippee
+bar : "yippee"
       EOS
       )
     end
@@ -244,11 +258,12 @@ bar=yippee
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
            :setting => 'foo', :value => 'yippee'))
       provider = described_class.new(resource)
-      provider.exists?.should be true
-      provider.value.should == 'blah'
+      expect(provider.exists?).to be true
+      expect(provider.value).to eq('blah')
       provider.value=('yippee')
       validate_file(<<-EOS
-foo=yippee
+# This is a comment
+foo="yippee"
 "test_key_1" {
     # yet another comment
     foo="http://192.168.1.1:8080"
@@ -261,7 +276,7 @@ foo=yippee
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
            :setting => 'foo', :value => 'blah'))
       provider = described_class.new(resource)
-      provider.exists?.should be true
+      expect(provider.exists?).to be true
     end
   end
 
@@ -278,13 +293,13 @@ foo=yippee
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
            :setting => 'foo', :value => 'yippee'))
       provider = described_class.new(resource)
-      provider.exists?.should be false
+      expect(provider.exists?).to be false
       provider.create
       validate_file(<<-EOS
 "test_key_2" {
     foo="http://192.168.1.1:8080"
 }
-foo=yippee
+foo : "yippee"
       EOS
       )
     end
@@ -314,10 +329,12 @@ EOS
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
       :setting => 'test_key_1.foo', :ensure => 'absent'))
       provider = described_class.new(resource)
-      provider.exists?.should be true
+      expect(provider.exists?).to be true
       provider.destroy
       validate_file(<<-EOS
 "test_key_1" {
+    # This is also a comment
+    
     bar=barvalue
     master=true
 }
@@ -337,7 +354,7 @@ EOS
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
                                                    :setting => 'test_key_3.foo', :ensure => 'absent'))
       provider = described_class.new(resource)
-      provider.exists?.should be false
+      expect(provider.exists?).to be false
       provider.destroy
       validate_file(<<-EOS
 "test_key_1" {


### PR DESCRIPTION
Modify the puppetlabs-hocon module to use the new ConfigDocument
API rather than the Config API for value addition/file rendering.