### PR TITLE
(TK-192) Support Arrays

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,6 @@ else
   gem 'puppet', :require => false
 end
 
-gem 'hocon', '~> 0.1.0',       :require => false
+gem 'hocon', '~> 0.9.0',       :require => false
 
 # vim:ft=ruby

--- a/README.markdown
+++ b/README.markdown
@@ -77,6 +77,19 @@ hocon_setting {'sample nested setting':
 
 * `value`: The value of the HOCON file setting to be defined.
 
+* `type`: The type of the value passed into the `value` parameter. This parameter will not be need to be set most of the time, as the module
+    is generally smart enough to figure this out on its own. There are only two cases in which this must be set.
+    
+    The first is the case in which the `value` type is a single-element array. In that case, the `type` parameter will need to be set to
+    `'array'`.
+    
+    Since this type represents a setting in a configuration file, you can pass a string containing the exact text of the value as you want it to appear
+    in the file (this is useful, for example, if you want to set a parameter to a map or an array but want comments or specific indentation on elements in the map/array).
+    In this case, `value` must be a string with no leading or trailing whitespace, newlines, or comments that contains a valid HOCON value, and the
+    `type` parameter must be set to `'text'`. This is an advanced use case, and will not be necessary for most users.
+    
+    Aside from these two cases, the `type` parameter does not need to be set.
+
 ##Development
  
 Puppet Labs modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can’t access the huge number of platforms and myriad of hardware, software, and deployment configurations that Puppet is intended to serve.

--- a/lib/puppet/provider/hocon_setting/ruby.rb
+++ b/lib/puppet/provider/hocon_setting/ruby.rb
@@ -62,7 +62,7 @@ Puppet::Type.type(:hocon_setting).provide(:ruby) do
   end
 
   def set_value(value)
-    if resource[:type] == 'array' || (value.is_a?(String) && resource[:type] != 'text')
+    if resource[:type] == 'array' || (value.is_a?(String) && resource[:type] != 'text') || (value.is_a?(Array) && value.size > 1)
       value = Hocon::ConfigValueFactory.from_any_ref(value, nil)
     elsif resource[:type] == 'text'
       value = value[0]

--- a/lib/puppet/provider/hocon_setting/ruby.rb
+++ b/lib/puppet/provider/hocon_setting/ruby.rb
@@ -17,8 +17,7 @@ Puppet::Type.type(:hocon_setting).provide(:ruby) do
   end
 
   def create
-    value = Hocon::ConfigValueFactory.from_any_ref(resource[:value], nil)
-    conf_file_modified = conf_file.set_config_value(setting, value)
+    conf_file_modified = set_value(resource[:value])
     Puppet::Util::ConfigSaver.save(resource[:path], conf_file_modified)
     @conf_file = nil
   end
@@ -34,8 +33,7 @@ Puppet::Type.type(:hocon_setting).provide(:ruby) do
   end
 
   def value=(value)
-    value = Hocon::ConfigValueFactory.from_any_ref(resource[:value], nil)
-    conf_file_modified = conf_file.set_config_value(setting, value)
+    conf_file_modified = set_value(value)
     Puppet::Util::ConfigSaver.save(resource[:path], conf_file_modified)
     @conf_file = nil
   end
@@ -61,6 +59,24 @@ Puppet::Type.type(:hocon_setting).provide(:ruby) do
       File.new(file_path, "w")
     end
     Hocon::ConfigFactory.parse_file(file_path)
+  end
+
+  def set_value(value)
+    if resource[:type] == 'array' || (value.is_a?(String) && resource[:type] != 'text')
+      value = Hocon::ConfigValueFactory.from_any_ref(value, nil)
+    elsif resource[:type] == 'text'
+      value = value[0]
+    else
+      value = Hocon::ConfigValueFactory.from_any_ref(value[0], nil)
+    end
+
+    if resource[:type] == 'text'
+      conf_file_modified = conf_file.set_value(setting, value)
+    else
+      conf_file_modified = conf_file.set_config_value(setting, value)
+    end
+
+    conf_file_modified
   end
 
 end

--- a/lib/puppet/type/hocon_setting.rb
+++ b/lib/puppet/type/hocon_setting.rb
@@ -32,27 +32,34 @@ Puppet::Type.newtype(:hocon_setting) do
     desc 'The value of the setting to be defined.'
 
     validate do |val|
+      # Grab the value we are going to validate
+      value = @shouldorig.is_a?(Array) && (@shouldorig.size > 1 || @resource[:type] == 'array') ? @shouldorig : @shouldorig[0]
       case @resource[:type]
+        when 'boolean'
+          if value != true && value != false
+            raise "Type specified as 'boolean' but was #{value.class}"
+          end
+        when 'string', 'text'
+          unless value.is_a?(String)
+            raise "Type specified as #{@resource[:type]} but was #{value.class}"
+          end
+        when 'number'
+          unless value.is_a?(Numeric)
+            raise "Type specified as 'number' but was #{value.class}"
+          end
+        when 'array'
+          unless value.is_a?(Array)
+            raise "Type specified as 'array' but was #{value.class}"
+          end
+        when 'hash'
+          unless value.is_a?(Hash)
+            raise "Type specified as 'hash' but was #{value.class}"
+          end
         when nil
-          if @shouldorig.is_a?(Array) and @shouldorig.size > 1
-            @resource[:type] = 'array'
-          else
-            case val.class.to_s.downcase.to_sym
-              when :trueclass, :falseclass
-                @resource[:type] = 'boolean'
-              else
-                @resource[:type] = 'string'
-            end
-          end
-        when 'hash', 'array', 'text'
-          # we're just leaving these values alone
+          # Do nothing, we'll figure it out on our own
         else
-          if @shouldorig.is_a?(Array) and @shouldorig.size > 1
-            raise "Array provided, but type specified as #{@resource[:type]}"
-          end
+          raise "Type was specified as #{@resource[:type]}, but should have been one of 'boolean', 'string', 'text', 'number', 'array', or 'hash'"
       end
     end
   end
-
-
 end

--- a/lib/puppet/type/hocon_setting.rb
+++ b/lib/puppet/type/hocon_setting.rb
@@ -22,8 +22,36 @@ Puppet::Type.newtype(:hocon_setting) do
     end
   end
 
-  newproperty(:value) do
+  newproperty(:type) do
+    desc "The value type"
+    # This property has no default. If it is not supplied, the validation of the "value"
+    # property will set one automatically.
+  end
+
+  newproperty(:value, :array_matching => :all) do
     desc 'The value of the setting to be defined.'
+
+    validate do |val|
+      case @resource[:type]
+        when nil
+          if @shouldorig.is_a?(Array) and @shouldorig.size > 1
+            @resource[:type] = 'array'
+          else
+            case val.class.to_s.downcase.to_sym
+              when :trueclass, :falseclass
+                @resource[:type] = 'boolean'
+              else
+                @resource[:type] = 'string'
+            end
+          end
+        when 'hash', 'array', 'text'
+          # we're just leaving these values alone
+        else
+          if @shouldorig.is_a?(Array) and @shouldorig.size > 1
+            raise "Array provided, but type specified as #{@resource[:type]}"
+          end
+      end
+    end
   end
 
 

--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -212,14 +212,106 @@ test_key_4 : { huzzah : "shazaam" }
       validate_file(" test_key_1 : { setting1 : \"helloworld\" }\n", emptyfile)
     end
 
-    it "should be able to handle variables of any type" do
+    it "should be able to handle variables of boolean type" do
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
-          :setting => 'test_key_1.master', :value => true))
+          :setting => 'test_key_1.master', :value => false))
       provider = described_class.new(resource)
+      provider.create
       expect(provider.exists?).to be true
-      expect(provider.value).to eql(true)
+      expect(provider.value).to eql(false)
     end
 
+    it "should be able to handle variables of integer type" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => 12))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value).to eql(12)
+    end
+
+    it "should be able to handle variables of float type" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => 12.24))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value).to eql(12.24)
+    end
+
+    it "should be able to handle arrays" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => [1, 2, 3, 4]))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value).to eql([1, 2, 3, 4])
+    end
+
+    it "should be able to handle maps" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => {"a" => 1, "b" => 2}))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value).to eql({"a" => 1, "b" => 2})
+    end
+
+    it "should treat a single-element array as a single value if no value type is specified" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => [12]))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value).to eql(12)
+    end
+
+    it "should treat a single-element array as a single-element array if value_type is specified" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => [12], :type => 'array'))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value).to eql([12])
+    end
+
+    it "should allow setting the exact text of a value in the file" do
+      text = "{\n  # a comment\n  a : b\n}"
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => text, :type => 'text'))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      validate_file(
+          <<-EOS
+# This is a comment
+test_key_1: {
+// This is also a comment
+  foo: foovalue
+
+  bar: barvalue
+  master: {
+    # a comment
+    a : b
+  }
+}
+
+test_key_2: {
+
+  foo: foovalue2
+  baz: bazvalue
+  url: "http://192.168.1.1:8080"
+}
+
+"test_key:3": {
+  foo: bar
+}
+    #another comment
+// yet another comment
+foo: bar
+      EOS
+      )
+    end
   end
 
   context "when dealing with settings in the top level" do

--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -467,4 +467,82 @@ EOS
       )
     end
   end
+
+  context "when validating a value type" do
+    let(:orig_content) { "" }
+    it "should throw when type is 'number' but value is not" do
+      expect {Puppet::Type::Hocon_setting.new(common_params.merge(
+                                        :setting => 'foo', :type => 'number', :value => "abcdefg"))}.to raise_error
+    end
+
+    it "should throw when type is 'boolean' but value is not" do
+      expect {Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                  :setting => 'foo', :type => 'boolean', :value => "abcdefg"))}.to raise_error
+    end
+
+    it "should throw when type is 'hash' but value is not" do
+      expect {Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                  :setting => 'foo', :type => 'hash', :value => "abcdefg"))}.to raise_error
+    end
+
+    it "should throw when type is 'string' but value is not" do
+      expect {Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                  :setting => 'foo', :type => 'string', :value => 12))}.to raise_error
+    end
+
+    it "should throw when type is 'text' but value is not" do
+      expect {Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                  :setting => 'foo', :type => 'text', :value => 12))}.to raise_error
+    end
+
+    it "should throw when type is a non-valid string" do
+      expect {Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                  :setting => 'foo', :type => 'invalid', :value => "abcdefg"))}.to raise_error
+    end
+
+    it "should be able to handle value false with boolean type specified" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => false, :type => 'boolean'))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value).to eql(false)
+    end
+
+    it "should be able to handle value true with boolean type specified" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => true, :type => 'boolean'))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value).to eql(true)
+    end
+
+    it "should be able to handle number value with number type specified" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => 12, :type => 'number'))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value).to eql(12)
+    end
+
+    it "should be able to handle string value with string type specified" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => "abc", :type => 'string'))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value).to eql("abc")
+    end
+
+    it "should be able to handle hash value with hash type specified" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => {'a' => 'b'}, :type => 'hash'))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value).to eql({'a' => 'b'})
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for Arrays, Hashes, and rendered text (the text of the value as it should appear in the configuration file) for the value parameter.

This PR is based on https://github.com/puppetlabs/puppetlabs-hocon/pull/7, so that should get merged before this is reviewed.

This PR will also require the changes in https://github.com/puppetlabs/ruby-hocon/pull/55 being released and the gemfile updated before it can be merged.