### PR TITLE
Handle stringified numerics

### DIFF
--- a/lib/puppet/provider/hocon_setting/ruby.rb
+++ b/lib/puppet/provider/hocon_setting/ruby.rb
@@ -8,8 +8,6 @@ end
 require File.expand_path('../../../util/config_saver', __FILE__)
 
 Puppet::Type.type(:hocon_setting).provide(:ruby) do
-  mk_resource_methods
-
   def self.namevar(section_name, setting)
     "#{setting}"
   end
@@ -28,6 +26,14 @@ Puppet::Type.type(:hocon_setting).provide(:ruby) do
     conf_file_modified = conf_file.remove_value(setting)
     Puppet::Util::ConfigSaver.save(resource[:path], conf_file_modified)
     @conf_file = nil
+  end
+
+  def type
+    @resource[:type]
+  end
+
+  def type=(value)
+    @resource[:type] = value
   end
 
   def value

--- a/lib/puppet/provider/hocon_setting/ruby.rb
+++ b/lib/puppet/provider/hocon_setting/ruby.rb
@@ -8,6 +8,8 @@ end
 require File.expand_path('../../../util/config_saver', __FILE__)
 
 Puppet::Type.type(:hocon_setting).provide(:ruby) do
+  mk_resource_methods
+
   def self.namevar(section_name, setting)
     "#{setting}"
   end

--- a/lib/puppet/type/hocon_setting.rb
+++ b/lib/puppet/type/hocon_setting.rb
@@ -44,7 +44,14 @@ Puppet::Type.newtype(:hocon_setting) do
             raise "Type specified as #{@resource[:type]} but was #{value.class}"
           end
         when 'number'
-          unless value.is_a?(Numeric)
+          # Puppet stringifies numerics in versions of Puppet < 4.0.0
+          # Account for this in the type
+          begin
+            numeric_as_string = Integer(value)
+          rescue ArgumentError
+            numeric_as_string = false
+          end
+          unless (value.is_a?(Numeric) or numeric_as_string)
             raise "Type specified as 'number' but was #{value.class}"
           end
         when 'array'
@@ -60,6 +67,13 @@ Puppet::Type.newtype(:hocon_setting) do
         else
           raise "Type was specified as #{@resource[:type]}, but should have been one of 'boolean', 'string', 'text', 'number', 'array', or 'hash'"
       end
+    end
+
+    munge do |value|
+      if value.is_a?(String) and @resource[:type] == 'number'
+        value = Integer(value)
+      end
+      value
     end
   end
 

--- a/lib/puppet/type/hocon_setting.rb
+++ b/lib/puppet/type/hocon_setting.rb
@@ -45,12 +45,11 @@ Puppet::Type.newtype(:hocon_setting) do
           end
         when 'number'
           # Puppet stringifies numerics in versions of Puppet < 4.0.0
-          # Account for this in the type
-          begin
-            numeric_as_string = Float(value)
-          rescue ArgumentError
-            numeric_as_string = false
-          end
+          # Account for this by first attempting to cast to an Integer.
+          # Failing that, attempt to cast to a Float or return false
+          numeric_as_string = Integer(value) rescue false
+          numeric_as_string = numeric_as_string ? numeric_as_string : Float(value) rescue false
+
           unless (value.is_a?(Numeric) or numeric_as_string)
             raise "Type specified as 'number' but was #{value.class}"
           end

--- a/lib/puppet/type/hocon_setting.rb
+++ b/lib/puppet/type/hocon_setting.rb
@@ -70,7 +70,8 @@ Puppet::Type.newtype(:hocon_setting) do
 
     munge do |value|
       if value.is_a?(String) and @resource[:type] == 'number'
-        value = Float(value)
+        munged_value = Integer(value) rescue false
+        value = munged_value ? munged_value : Float(value)
       end
       value
     end

--- a/lib/puppet/type/hocon_setting.rb
+++ b/lib/puppet/type/hocon_setting.rb
@@ -47,7 +47,7 @@ Puppet::Type.newtype(:hocon_setting) do
           # Puppet stringifies numerics in versions of Puppet < 4.0.0
           # Account for this in the type
           begin
-            numeric_as_string = Integer(value)
+            numeric_as_string = Float(value)
           rescue ArgumentError
             numeric_as_string = false
           end
@@ -71,7 +71,7 @@ Puppet::Type.newtype(:hocon_setting) do
 
     munge do |value|
       if value.is_a?(String) and @resource[:type] == 'number'
-        value = Integer(value)
+        value = Float(value)
       end
       value
     end

--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -541,7 +541,6 @@ EOS
       provider = described_class.new(resource)
       provider.create
       expect(provider.exists?).to be true
-      #expect(provider.value[0]).to eql(12)
       expect(provider.value[0].eql?(12)).to be(true)
     end
 

--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -526,6 +526,15 @@ EOS
       expect(provider.value[0]).to eql(12)
     end
 
+    it "should be able to handle a numerical string value with number type specified" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => '12', :type => 'number'))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value[0]).to eql(12)
+    end
+
     it "should be able to handle string value with string type specified" do
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
                                                      :setting => 'test_key_1.master', :value => "abc", :type => 'string'))

--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -526,13 +526,22 @@ EOS
       expect(provider.value[0]).to eql(12)
     end
 
-    it "should be able to handle a numerical string value with number type specified" do
+    it "should be able to handle an Integer string value with number type specified" do
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
                                                      :setting => 'test_key_1.master', :value => '12', :type => 'number'))
       provider = described_class.new(resource)
       provider.create
       expect(provider.exists?).to be true
       expect(provider.value[0]).to eql(12)
+    end
+
+    it "should be able to handle a Float string value with number type specified" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => '13.37', :type => 'number'))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value[0]).to eql(13.37)
     end
 
     it "should be able to handle string value with string type specified" do

--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -517,13 +517,22 @@ EOS
       expect(provider.value[0]).to eql(true)
     end
 
-    it "should be able to handle number value with number type specified" do
+    it "should be able to handle an integer value with number type specified" do
       resource = Puppet::Type::Hocon_setting.new(common_params.merge(
                                                      :setting => 'test_key_1.master', :value => 12, :type => 'number'))
       provider = described_class.new(resource)
       provider.create
       expect(provider.exists?).to be true
-      expect(provider.value[0]).to eql(12)
+      expect(provider.value[0].eql?(12)).to be(true)
+    end
+
+    it "should be able to handle a float value with number type specified" do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                     :setting => 'test_key_1.master', :value => 13.37, :type => 'number'))
+      provider = described_class.new(resource)
+      provider.create
+      expect(provider.exists?).to be true
+      expect(provider.value[0].eql?(13.37)).to be(true)
     end
 
     it "should be able to handle an Integer string value with number type specified" do
@@ -532,7 +541,8 @@ EOS
       provider = described_class.new(resource)
       provider.create
       expect(provider.exists?).to be true
-      expect(provider.value[0]).to eql(12)
+      #expect(provider.value[0]).to eql(12)
+      expect(provider.value[0].eql?(12)).to be(true)
     end
 
     it "should be able to handle a Float string value with number type specified" do
@@ -541,7 +551,7 @@ EOS
       provider = described_class.new(resource)
       provider.create
       expect(provider.exists?).to be true
-      expect(provider.value[0]).to eql(13.37)
+      expect(provider.value[0].eql?(13.37)).to be(true)
     end
 
     it "should be able to handle string value with string type specified" do

--- a/spec/unit/puppet/type/hocon_setting_spec.rb
+++ b/spec/unit/puppet/type/hocon_setting_spec.rb
@@ -1,0 +1,124 @@
+require 'puppet'
+require 'puppet/type/hocon_setting'
+describe Puppet::Type.type(:hocon_setting) do
+  let(:resource) {
+    Puppet::Type.type(:hocon_setting).new(
+      :name       => 'hocon setting',
+      :path       => '/tmp/hocon.setting',
+      :setting    => 'test_key.master',
+      :value      => 'value',
+      :type       => 'text'
+    )
+  }
+
+  it 'is ensurable' do
+    resource[:ensure] = :present
+    expect(resource[:ensure]).to be(:present)
+    resource[:ensure] = :absent
+    expect(resource[:ensure]).to be(:absent)
+  end
+
+  it 'raises an error if an invalid ensure value is passed' do
+    expect { resource[:ensure] = 'file' }.to raise_error \
+      Puppet::Error, /Invalid value "file"/
+  end
+
+  it 'accepts a valid type value' do
+    valid_types = [
+      'boolean',
+      'string',
+      'text',
+      'number',
+      'array',
+      'hash'
+    ]
+
+    valid_types.each do |t|
+      resource[:type] = t
+      expect(resource[:type]).to eq(t)
+    end
+  end
+
+  it 'raises an error with invalid type values when a value is specified' do
+    resource[:type]  = 'blarg'
+    expect { resource[:value] = 4 }.to raise_error \
+      Puppet::Error, /Type was specified as blarg, but should have been one of 'boolean'/
+  end
+
+  it 'accepts valid boolean values' do
+    resource[:type] = 'boolean'
+    [true, false].each do |val|
+      resource[:value] = val
+      expect(resource[:value]).to eq([val])
+    end
+  end
+
+  it 'raises an error with invalid boolean values' do
+    resource[:type]  = 'boolean'
+    expect { resource[:value] = 'not boolean' }.to raise_error \
+      Puppet::Error, /Type specified as 'boolean' but was String/
+  end
+
+  it 'accepts valid string and text values' do
+    ['string', 'text'].each do |t|
+      resource[:type] = t
+      resource[:value] = 'string value'
+      expect(resource[:value]).to eq(['string value'])
+    end
+  end
+
+  it 'raises an error with invalid string and text values' do
+    ['string', 'text'].each do |t|
+      resource[:type]  = t
+      expect { resource[:value] = 4 }.to raise_error \
+        Puppet::Error, /Type specified as #{t} but was Fixnum/
+    end
+  end
+
+  it 'accepts valid number values' do
+    [13, 13.37].each do |t|
+      resource[:type]  = 'number'
+      resource[:value] = t
+      expect(resource[:value]).to eq([t])
+    end
+  end
+
+  it 'accepts valid number values as a string' do
+    {
+      '13'    => 13,
+      '13.37' => 13.37
+    }.each do |key, val|
+      resource[:type]  = 'number'
+      resource[:value] = key
+      expect(resource[:value].eql?([val])).to be(true)
+    end
+  end
+
+  it 'raises an error with invalid number values' do
+    ['string', '45g'].each do |t|
+      resource[:type]  = 'number'
+      expect { resource[:value] = t }.to raise_error \
+        Puppet::Error, /Type specified as 'number' but was String/
+    end
+  end
+
+  it 'accepts valid array values' do
+    array = ['foo', 'bar']
+    resource[:type]  = 'array'
+    resource[:value] = array
+    expect(resource[:value]).to eq(array)
+  end
+
+  it 'accepts valid hash values' do
+    hash = { 'key' => 'value' }
+    resource[:type]  = 'hash'
+    resource[:value] = hash
+    expect(resource[:value]).to eq([hash])
+  end
+
+  it 'raises an error with invalid hash values' do
+    resource[:type]  = 'hash'
+    expect { resource[:value] = 4 }.to raise_error \
+      Puppet::Error, /Type specified as 'hash' but was Fixnum/
+  end
+end


### PR DESCRIPTION
Previously, the type would check the type of value being passed in the DSL
and would use that type when setting the value in the Hocon config file
(i.e. a string value would be a string in the config file, and an array
would be an array value). The problem is that versions of Puppet < 4.0.0
stringify all values passed in the DSL, so it was impossible to pass a true
numeric value via the DSL (since it would be stringified).

This commit updates the type validation to account for this and implements
a munge block to convert the value type to a numeric. A test for this case
has also been added.