### PR TITLE
(MAINT) Update to hocon 0.9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,6 @@ else
   gem 'puppet', :require => false
 end
 
-gem 'hocon', '~> 0.9.0',       :require => false
+gem 'hocon', '~> 0.9.2',       :require => false
 
 # vim:ft=ruby

--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -198,7 +198,9 @@ test_key_2: {
     #another comment
 // yet another comment
 foo: bar
-test_key_4 : { huzzah : "shazaam" }
+test_key_4 : {
+  huzzah : "shazaam"
+}
       EOS
       )
     end
@@ -209,7 +211,7 @@ test_key_4 : { huzzah : "shazaam" }
       provider = described_class.new(resource)
       expect(provider.exists?).to be false
       provider.create
-      validate_file(" test_key_1 : { setting1 : \"helloworld\" }\n", emptyfile)
+      validate_file("test_key_1 : {\n  setting1 : \"helloworld\"\n}\n", emptyfile)
     end
 
     it "should be able to handle variables of boolean type" do


### PR DESCRIPTION
Due to a bug in the hocon gem, the hocon module would previously
generate ugly single-line configuration when creating a config
from scratch. Update to hocon 0.9.2 to remove this behavior.