### PR TITLE
Implement hocon::file convenience type

### DIFF
--- a/lib/puppet/functions/hocon/resources_from_template.rb
+++ b/lib/puppet/functions/hocon/resources_from_template.rb
@@ -1,0 +1,43 @@
+require 'puppet/util/feature'
+if Puppet.features.hocon?
+  require 'hocon/config_factory'
+  require 'hocon/parser/config_document_factory'
+  require 'hocon/config_value_factory'
+end
+
+Puppet::Functions.create_function(:"hocon::resources_from_template") do
+
+  dispatch :create do
+    required_param 'Enum["present", "absent"]', :ensure
+    required_param 'String',                    :path
+    required_param 'String',                    :content
+    optional_param 'Hash[Scalar, Any]',         :defaults
+  end
+
+  def create(x_ensure, path, content, defaults = {})
+    hocon_hash = Hocon.parse(content)
+    resources = hash_to_properties(hocon_hash).inject({}) do |hash,elem|
+      hash.merge("#{path} #{elem[:key]}" => defaults.merge({
+        'ensure'  => x_ensure,
+        'path'    => path,
+        'setting' => elem[:key],
+        'value'   => elem[:value]
+      }))
+    end
+    call_function(:create_resources, 'hocon_setting', resources)
+  end
+
+  def hash_to_properties(value, key = '')
+    return [{:value => value}] unless value.is_a?(Hash)
+    result = Array.new
+    value.each do |k,v|
+      result << hash_to_properties(v,k).map do |elem|
+        # k = conv_to_s(k)
+        elem[:key] = elem[:key] ? "#{k}.#{elem[:key]}" : k
+        elem
+      end
+    end
+    result.flatten
+  end
+
+end

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -1,0 +1,34 @@
+define hocon::file (
+  String
+    $content,
+  String
+    $path = $title,
+  Enum['present', 'absent']
+    $ensure = present,
+  Boolean
+    $purge = false,
+  Variant[Undef, String, Integer]
+    $owner = undef,
+  Variant[Undef, String, Integer]
+    $group = undef,
+  Variant[Undef, String]
+    $mode = undef,
+) {
+
+  file { $path:
+    ensure  => $ensure,
+    content => $content,
+    owner   => $owner,
+    group   => $group,
+    mode    => $mode,
+    replace => $purge,
+  }
+
+  hocon::resources_from_template(
+    $ensure,
+    $path,
+    $content,
+    { 'subscribe' => File[$path] },
+  )
+
+}


### PR DESCRIPTION
I put this together as an experiment awhile back. Putting it in a PR for feedback on whether or not this is something worth having.

The only new public interface is the `hocon::file` defined type.

The hocon_setting type allows users to describe individual pieces of configuration that they need, but doesn't let them step back and describe at a higher level that a wholistic configuration file is what they care about.

It is technically desirable not to use templates for managing configuration, as it is impossible to be additive about configuration with templates. However, templates make a lot of sense for defining a baseline from which to start and be additive about. See https://github.com/TERC/puppet-xmlfile for another example of this desire.

This commit introduces a new defined type that allows users to build a whole-file template representing a base configuration to deploy, but does not have any of the brittleness of a template.

Example:

````puppet
hocon::file { '/tmp/test.conf':
  ensure  => present,
  content => template('/Users/reidmv/src/test.conf.erb'),
  purge   => false,
  owner   => 'root',
  group   => 'root',
  mode    => '0644',
}
````

The defined type first declares the file resource but sets replace=false. When Puppet runs it will create the file and populate it with the template content.

Next, a function is added which parses the template content and creates a hocon_setting resource for each element found in the template. These resources are added to the catalog.

Because a template was used to create the file, formatting and comments can be preserved on creation. Because Puppet will never overwrite an existing file though, local edits or hocon_setting resources that add additional configs will be work correctly.

Because a function parses the template and adds hocon_setting resources to the catalog for each setting, Puppet will continue to enforce that desired configuration is preserved, even though the file resource will never replace the file contents wholesale.

In general the new hocon::file defined type allows users to manage Hocon configuration files by focusing on the file instead of individual settings inside it. Similar to the recurse=true file directory pattern, users define a whole naturally in a wysiwyg manner, but aren't prevented from adding in additional parameters later.

**Caveat**: the hocon_setting namevar does not appear to be able to establish true namevar reference to a resource. The `hocon::file` interface could be significantly strengthened if we could use hocon_setting namevars to ensure uniqueness in the catalog.