### PR TITLE
(HC-33) Support adding element when array does not exist yet

### DIFF
--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -110,6 +110,90 @@ test_key_1: [
       EOS
 )
     end
+
+    it "should add an array element even if the target setting does not yet exist" do
+      resource = Puppet::Type::Hocon_setting.new(
+          common_params.merge(:setting => 'test_key_2',
+                              :ensure => 'present',
+                              :value => { 'foo' => 'foovalue3' },
+                              :type => 'array_element'))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be false
+      provider.create
+      validate_file(
+          <<-EOS
+test_key_1: [
+  {
+    foo: foovalue
+    bar: barvalue
+    master: true
+  }
+,
+  {
+    foo: foovalue2
+    baz: bazvalue
+    url: "http://192.168.1.1:8080"
+  }
+,
+  {
+    foo: foovalue3
+  }
+]
+test_key_2 : [
+
+    {
+
+        "foo" : "foovalue3"
+
+    }
+
+
+
+]
+      EOS
+      )
+    end
+
+    it "should add an array element even if the target setting is not an array" do
+      File.open(tmpfile, 'a') do |fh|
+        fh.write('test_key_2: 3')
+      end
+      resource = Puppet::Type::Hocon_setting.new(
+          common_params.merge(:setting => 'test_key_2',
+                              :ensure => 'present',
+                              :value => { 'foo' => 'foovalue3' },
+                              :type => 'array_element'))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be false
+      provider.create
+      validate_file(
+          <<-EOS
+test_key_1: [
+  {
+    foo: foovalue
+    bar: barvalue
+    master: true
+  }
+,
+  {
+    foo: foovalue2
+    baz: bazvalue
+    url: "http://192.168.1.1:8080"
+  }
+,
+  {
+    foo: foovalue3
+  }
+]
+test_key_2: [
+    {
+        "foo" : "foovalue3"
+    }
+
+]
+      EOS
+      )
+    end
   end
 
   context "when ensuring that a setting is present" do


### PR DESCRIPTION
This commit changes the behavior for applying an `array_element` when
the array does not exist in the target file yet from displaying an error
to creating the array and populating it with the element.