### PR TITLE
(HC-31) Handle type change from scalar -> array

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem 'beaker',                       :require => false
   gem 'beaker-rspec', '>= 2.2',       :require => false
   gem 'pry',                          :require => false
+  gem 'pry-nav',                      :require => false
   gem 'simplecov',                    :require => false
   gem 'beaker-puppet_install_helper', :require => false
 end

--- a/lib/puppet/provider/hocon_setting/ruby.rb
+++ b/lib/puppet/provider/hocon_setting/ruby.rb
@@ -11,21 +11,31 @@ Puppet::Type.type(:hocon_setting).provide(:ruby) do
   end
 
   def exists?
-    ret_value = false
+    unless conf_file.has_value?(setting)
+      return false
+    end
 
-    if conf_file.has_value?(setting)
-      if resource[:type] == 'array_element'
-        Array(@resource[:value]).each do |v|
-          if value.flatten.include?(v)
-            return true
-          end
-        end
-      else
-        ret_value = true
+    type = @resource[:type]
+    conf_value = conf_object.get_value(setting).value
+
+    if type == 'array'
+      unless conf_value.is_a?(Array)
+        return false
       end
     end
 
-    return ret_value
+    if type == nil &&
+       conf_value.is_a?(Array) &&
+       conf_value.length == 1
+
+      return false
+    end
+
+    if type == 'array_element'
+      return Array(@resource[:value]).any? { |v| value.flatten.include?(v) }
+    end
+
+    return true
   end
 
   def create

--- a/lib/puppet/type/hocon_setting.rb
+++ b/lib/puppet/type/hocon_setting.rb
@@ -77,6 +77,8 @@ Puppet::Type.newtype(:hocon_setting) do
     end
 
     def insync?(is)
+      # TODO this doesn't appear to get called, and according to Puppet's source
+      # it may be deprecated.
       if @resource[:type] == 'array_element'
         # make sure all passed values are in the file
         Array(@resource[:value]).each do |v|

--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -194,6 +194,49 @@ test_key_2: [
       EOS
       )
     end
+
+    it "should convert a scalar key to a single element array when type is set" do
+      File.open(tmpfile, 'w') do |fh|
+        fh.write('ennui: yes')
+      end
+      resource = Puppet::Type::Hocon_setting.new(
+        common_params.merge(:setting => 'ennui',
+                            :ensure => 'present',
+                            :value => ['yes'],
+                            :type => 'array'))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be false
+      provider.create
+      expect(provider.exists?).to be true
+      validate_file(
+        <<-EOS
+ennui: [
+    "yes"
+]
+EOS
+      )
+    end
+
+    it "should convert to a scalar from single element array when type is unset" do
+      content = <<-EOS
+ennui: [
+    "yes"
+]
+EOS
+      File.open(tmpfile, 'w') do |fh|
+        fh.write(content)
+      end
+      resource = Puppet::Type::Hocon_setting.new(
+        common_params.merge(:setting => 'ennui',
+                            :ensure => 'present',
+                            :value => ['yes'],))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be false
+      provider.create
+      expect(provider.exists?).to be true
+      validate_file("ennui: \"yes\"\n")
+    end
+
   end
 
   context "when ensuring that a setting is present" do


### PR DESCRIPTION
Previously, if a setting existed on disk as a scalar and the puppet resource changed the setting's type to array, the file would not be updated to reflect this explicit type.

In addition to the new unit test, I manually tested this and saw the fix working locally. I am unable to run the acceptance tests.

I've never touched types and providers before and have barely written ruby, so in many ways I feel like I was coding in the dark. Extra scrutiny on this PR would be great!