### PR TITLE
(HC-46) Confine provider based on hocon feature

### DIFF
--- a/lib/puppet/feature/hocon.rb
+++ b/lib/puppet/feature/hocon.rb
@@ -1,4 +1,9 @@
 require 'puppet/util/feature'
 
-Puppet.features.add(:hocon, :libs => ['hocon'])
+libs = ['hocon',
+        'hocon/config_factory',
+        'hocon/config_value_factory',
+        'hocon/parser/config_document_factory'
+       ]
 
+Puppet.features.add(:hocon, :libs => libs)

--- a/lib/puppet/provider/hocon_setting/ruby.rb
+++ b/lib/puppet/provider/hocon_setting/ruby.rb
@@ -1,11 +1,6 @@
-require 'puppet/util/feature'
-if Puppet.features.hocon?
-  require 'hocon/config_factory'
-  require 'hocon/parser/config_document_factory'
-  require 'hocon/config_value_factory'
-end
-
 Puppet::Type.type(:hocon_setting).provide(:ruby) do
+  confine :feature => :hocon
+
   def self.namevar(section_name, setting)
     "#{setting}"
   end


### PR DESCRIPTION
Previously, we guarded requiring the hocon gem based on the feature, but
we never re-evaluated the feature, so you couldn't use the hocon module
in the same run that the hocon gem was installed.

This commit moves the requiring logic into the feature definition, and
confines the provider based on the hocon feature.