### PR TITLE
(HC-30) Make path and setting namevars

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,16 +81,25 @@ hocon_setting { 'sample map setting':
 
 * `ensure`: Ensures that the resource is present. Valid values are 'present', 'absent'.
 
-* `name`: An arbitrary name used as the identity of the resource.
-
 * `path`: The HOCON file in which Puppet will ensure the specified setting.
+  
+  This parameter, along with `setting`, is one of two namevars for the
+  `hocon_setting` type, meaning that Puppet will give an error if two `hocon_setting` resources have the same `setting`
+  and `path` parameters.
 
 * `provider`: The specific backend to use for this `hocon_setting` resource. You will seldom need to specify this --- Puppet will usually discover the appropriate provider for your platform. The only available provider for `hocon_setting` is ruby.
 
 * `setting`: The name of the HOCON file setting to be defined. This can be a top-level setting or a setting nested
   within another setting. To define a nested setting, give the full path to that setting with each level separated
   by a `.` So, to define a setting `foosetting` nested within a setting called `foo` contained on the top level,
-  the `setting` parameter would be set to `foo.foosetting`.
+  the `setting` parameter would be set to `foo.foosetting`. 
+  
+  This parameter, along with `path`, is one of two namevars for the
+  `hocon_setting` type, meaning that Puppet will give an error if two `hocon_setting` resources have the same `setting`
+  and `path` parameters. 
+  
+  If no `setting` value is explicitly set, the title of the resource will be used
+  as the value of `setting`.
 
 * `value`: The value of the HOCON file setting to be defined.
 

--- a/lib/puppet/type/hocon_setting.rb
+++ b/lib/puppet/type/hocon_setting.rb
@@ -5,15 +5,11 @@ Puppet::Type.newtype(:hocon_setting) do
     defaultto :present
   end
 
-  newparam(:name, :namevar => true) do
-    desc 'An arbitrary name used as the identity of the resource.'
-  end
-
-  newparam(:setting) do
+  newparam(:setting, :namevar => true) do
     desc 'The name of the setting to be defined.'
   end
 
-  newparam(:path) do
+  newparam(:path, :namevar => true) do
     desc 'The file Puppet will ensure contains the specified setting.'
     validate do |value|
       unless (Puppet.features.posix? and value =~ /^\//) or (Puppet.features.microsoft_windows? and (value =~ /^.:\// or value =~ /^\/\/[^\/]+\/[^\/]+/))
@@ -104,6 +100,14 @@ Puppet::Type.newtype(:hocon_setting) do
         super
       end
     end
+  end
+
+  def self.title_patterns
+    # This is the default title pattern for all types, except hard-wired to
+    # set the title to :setting instead of :name. This is also hard-wired to
+    # ONLY set :setting and nothing else, and this will be overridden if
+    # the :setting parameter is set manually.
+    [ [ /(.*)/m, [ [:setting] ] ] ]
   end
 
   validate do

--- a/spec/unit/puppet/type/hocon_setting_spec.rb
+++ b/spec/unit/puppet/type/hocon_setting_spec.rb
@@ -3,7 +3,7 @@ require 'puppet/type/hocon_setting'
 describe Puppet::Type.type(:hocon_setting) do
   let(:resource) {
     Puppet::Type.type(:hocon_setting).new(
-      :name       => 'hocon setting',
+      :title      => 'hocon setting',
       :path       => '/tmp/hocon.setting',
       :setting    => 'test_key.master',
       :value      => 'value',


### PR DESCRIPTION
Make the path and setting parameters namevars, thus ensuring that
Puppet will give an error if two resources manage the same hocon
setting in the same file.

To implement this I ended up needing to make some changes to the API. This change should be compatible with all existing puppet code written using the `hocon_setting` type unless the user was explicitly setting `name`. 

When we release this change we should either release the module as 0.10.0 or 1.0.0.