### PR TITLE
(maint) Update PuppetLint configuration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,10 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
-PuppetLint.configuration.fail_on_warnings
-PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.send('relative')
+PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
-PuppetLint.configuration.send('disable_class_parameter_defaults')
 PuppetLint.configuration.send('disable_documentation')
 PuppetLint.configuration.send('disable_single_quote_string_with_variables')
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "bundle/**/*", "vendor/**/*"]


### PR DESCRIPTION
Update the PuppetLint configuration to prevent failures in CI.
Eventually we'll need to add hocon to modulesync but in the mean
time this will prevent failures.