### PR TITLE
(maint) Fix indentation error in test file

### DIFF
--- a/tests/hocon_setting.pp
+++ b/tests/hocon_setting.pp
@@ -6,11 +6,11 @@ hocon_setting { 'sample setting':
 }
 
 hocon_setting { 'sample setting2':
-  ensure            => present,
-  path              => '/tmp/foo.conf',
-  setting           => 'bar.barsetting',
-  value             => 'BAR!',
-  require           => Hocon_setting['sample setting'],
+  ensure  => present,
+  path    => '/tmp/foo.conf',
+  setting => 'bar.barsetting',
+  value   => 'BAR!',
+  require => Hocon_setting['sample setting'],
 }
 
 hocon_setting { 'sample setting3':


### PR DESCRIPTION
Prior to this commit there was an indentation error in
hocon_settings.pp that was causing lint to issue a warning and thus
CI jobs to fail. Fix the indention in the file so that lint no
longer finds any issues to warn about.