### PR TITLE
(HC-91) Make tests compatible with newer ruby versions

### DIFF
--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -13,9 +13,9 @@ describe provider_class do
       :path     => tmpfile,
   } }
 
-  def validate_file(expected_content,tmpfile = tmpfile)
-    tmpcontent = File.read(tmpfile)
-    expect(File.read(tmpfile)).to eq(expected_content)
+  def validate_file(expected_content,tmp = tmpfile)
+    tmpcontent = File.read(tmp)
+    expect(File.read(tmp)).to eq(expected_content)
   end
 
 


### PR DESCRIPTION
Prior to this commit, some of the spec tests were failing on Ruby
2.2 and newer. This was due to the fact that the way variable names
are handled and scoped had changed, and we were unintentionally
overloading a variable name. In order to fix this issue, change
one of the variable names so they do not conflict.