### PR TITLE
(HC-94) Unpin the hocon gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,6 @@ else
   gem 'puppet', :require => false
 end
 
-gem 'hocon', '~> 0.9.3',       :require => false
+gem 'hocon', :require => false
 
 # vim:ft=ruby


### PR DESCRIPTION
Prior to this commit, the version of the hocon gem for this module
was pinned to 0.9.3. There have been several new releases since then,
but since the version is pinned in the Gemfile the module is still
using an old release of the gem.

The version was originally pinned to avoid breaking the vsphere
and azure modules, but both modules now require hocon version 1.0.0+
so it is no longer neccesary for the module to continue using an
older version.
