### PR TITLE
(maint) Actually fix conditional statement

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,7 +7,7 @@ unless ENV['RS_PROVISION'] == 'no'
   hosts.each do |host|
     puppet_version = (on default, puppet('--version')).output.chomp
 
-    if Gem::Version.new(puppet_version).to_s =~ /Puppet Enterprise /
+    if puppet_version =~ /Puppet Enterprise /
       on host, puppet('resource package hocon provider=pe_gem')
     elsif ENV['PUPPET_INSTALL_TYPE'] != 'foss' && Gem::Version.new(puppet_version) >= Gem::Version.new('4.0.0')
       on host, puppet('resource package hocon provider=puppet_gem')


### PR DESCRIPTION
The previous commit contained an error. Unwrap 'puppet_version' in
the first conditional statement, it should not be passed into
Gem::Version.new().to_s first.