### PR TITLE
(MODULES-4854) remove allow_deprecations

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,8 +3,6 @@ appveyor.yml:
   delete: true
 .travis.yml:
   hipchat: ZnXjXpfn2I11z1/x4DS+o2YnTW5Gll8xMOXvF68HyTQTtJCgIXVzmyq6w1oNAKDBEOm6jWJ6kQA2fD2GSktk+Py0hDkNs232BGDf1nvQ7naBXZMfpkdwVG4hYNR20iirJW5FN2BaqoU8KusForv/Sp6veQkVo7Tw0BjfgFiJKP8=
-spec/spec_helper.rb:
-  allow_deprecations: true
 Gemfile:
   optional:
     ':development':


### PR DESCRIPTION
This module has been released to drop puppet 3 so we will no longer allow deprecated functions via unit testing.