### PR TITLE
Updating supported OS for Ubuntu and Debian

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,13 +14,16 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04"
+        "14.04",
+        "16.04"
       ]
     }
   ],


### PR DESCRIPTION
Adding Debian and Ubuntu supported versions to align with the following document: https://puppet.com/docs/pe/2017.3/installing/supported_operating_systems.html.