### PR TITLE
(maint) Resolve config object before manipulating it

### DIFF
--- a/lib/puppet/provider/hocon_setting/ruby.rb
+++ b/lib/puppet/provider/hocon_setting/ruby.rb
@@ -107,7 +107,7 @@ Puppet::Type.type(:hocon_setting).provide(:ruby) do
     if @conf_file.nil? && !File.exist?(file_path)
       File.new(file_path, 'w')
     end
-    Hocon::ConfigFactory.parse_file(file_path)
+    Hocon::ConfigFactory.parse_file(file_path).resolve
   end
 
   def remove_value(value_to_remove)

--- a/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
+++ b/spec/unit/puppet/provider/conf_setting/ruby_spec.rb
@@ -839,4 +839,33 @@ EOS
       expect(provider.value[0]).to eql('a' => 'b')
     end
   end
+
+  context 'substitutions' do
+    let(:orig_content) do
+      <<-EOS
+test_key_1:
+  {
+    bar: barvalue
+  }
+sub_key: ${test_key_1.bar}
+      EOS
+    end
+
+    it 'can change the value of a setting with a substitution' do
+      resource = Puppet::Type::Hocon_setting.new(common_params.merge(
+                                                   setting: 'sub_key', ensure: 'present', value: 'newvalue', type: 'string',
+      ))
+      provider = described_class.new(resource)
+      expect(provider.exists?).to be true
+      provider.value = 'newvalue'
+      validate_file(<<-EOS
+test_key_1:
+  {
+    bar: barvalue
+  }
+sub_key: "newvalue"
+      EOS
+                   )
+    end
+  end
 end


### PR DESCRIPTION
The ConfigDocument API that preserves comments and formatting in HOCON
files does not automatically resolve substitutions. This makes it
impossible to manipulate settings that involve substitutions. This
commit adds a `resolve` call to the config object that is parsed and
provided for manipulation.