### PR TITLE
Run pdk update to obtain .travis.yml template update

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,7 +1,4 @@
 ---
-.travis.yml:
-  unmanaged: true
-
 Gemfile:
   optional:
     ':development':
@@ -22,3 +19,67 @@ appveyor.yml:
 Rakefile:
   requires:
     - puppet-lint/tasks/puppet-lint
+
+'.travis.yml':
+  deploy_to_forge:
+    enabled: false
+  branches:
+    - release
+  user: puppet
+  secure: ''
+  includes:
+    - bundler_args:
+      dist: trusty
+      env: PLATFORMS=deb_puppet5
+      rvm: 2.5.3
+      before_script:
+        - bundle exec rake 'litmus:provision_list[travis_deb]'
+        - bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'
+        - bundle exec rake 'litmus:install_agent[puppet5]'
+        - bundle exec rake litmus:install_module
+      script:
+        - bundle exec rake litmus:acceptance:parallel
+      services: docker
+      stage: acceptance
+      sudo: required
+    - bundler_args:
+      dist: trusty
+      env: PLATFORM=centos:deb_puppet6
+      rvm: 2.5.3
+      before_script:
+        - bundle exec rake 'litmus:provision_list[travis_deb]'
+        - bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'
+        - bundle exec rake 'litmus:install_agent[puppet6]'
+        - bundle exec rake litmus:install_module
+      script:
+        - bundle exec rake litmus:acceptance:parallel
+      services: docker
+      sudo: required
+      stage: acceptance
+    - bundler_args:
+      dist: trusty
+      env: PLATFORMS=el_puppet5
+      rvm: 2.5.3
+      before_script:
+        - bundle exec rake 'litmus:provision_list[travis_el]'
+        - bundle exec rake 'litmus:install_agent[puppet5]'
+        - bundle exec rake litmus:install_module
+      script:
+        - bundle exec rake litmus:acceptance:parallel
+      services: docker
+      sudo: required
+      stage: acceptance
+    - bundler_args:
+      dist: trusty
+      env: PLATFORM=centos:el_puppet6
+      rvm: 2.5.3
+      before_script:
+        - bundle exec rake 'litmus:provision_list[travis_el]'
+        - bundle exec rake 'litmus:install_agent[puppet6]'
+        - bundle exec rake litmus:install_module
+      script:
+        - bundle exec rake litmus:acceptance:parallel
+      services: docker
+      stage: acceptance
+      sudo: required
+  simplecov: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ cache: bundler
 before_install:
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system $RUBYGEMS_VERSION
+  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+  - "# See https://github.com/puppetlabs/pdk-templates/commit/705154d5c437796b821691b707156e1b056d244f for an example of how this was used"
+  - '[ -z "$RUBYGEMS_VERSION" ] || yes | gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
 script:
-  - 'bundle exec rake $CHECK'
+  - 'SIMPLECOV=yes bundle exec rake $CHECK'
 bundler_args: --without system_tests
 rvm:
   - 2.5.3
@@ -17,66 +19,9 @@ stages:
   - static
   - spec
   - acceptance
-  -
-    if: tag =~ ^v\d
-    name: deploy
 matrix:
   fast_finish: true
   include:
-    -
-      bundler_args:
-      dist: trusty
-      env: PLATFORMS=deb_puppet5
-      rvm: 2.5.1
-      before_script:
-      - bundle exec rake 'litmus:provision_list[travis_deb]'
-      - bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='*'
-      - bundle exec rake 'litmus:install_agent[puppet5]'
-      - bundle exec rake litmus:install_module
-      script:
-      - bundle exec rake litmus:acceptance:parallel
-      services: docker
-      sudo: required
-    -
-      bundler_args:
-      dist: trusty
-      env: PLATFORMS=deb_puppet6
-      rvm: 2.5.1
-      before_script:
-      - bundle exec rake 'litmus:provision_list[travis_deb]'
-      - bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='*'
-      - bundle exec rake 'litmus:install_agent[puppet6]'
-      - bundle exec rake litmus:install_module
-      script:
-      - bundle exec rake litmus:acceptance:parallel
-      services: docker
-      sudo: required
-    -
-      bundler_args:
-      dist: trusty
-      env: PLATFORMS=el_puppet5
-      rvm: 2.5.1
-      before_script:
-      - bundle exec rake 'litmus:provision_list[travis_el]'
-      - bundle exec rake 'litmus:install_agent[puppet5]'
-      - bundle exec rake litmus:install_module
-      script:
-      - bundle exec rake litmus:acceptance:parallel
-      services: docker
-      sudo: required
-    -
-      bundler_args:
-      dist: trusty
-      env: PLATFORMS=el_puppet6
-      rvm: 2.5.1
-      before_script:
-      - bundle exec rake 'litmus:provision_list[travis_el]'
-      - bundle exec rake 'litmus:install_agent[puppet6]'
-      - bundle exec rake litmus:install_module
-      script:
-      - bundle exec rake litmus:acceptance:parallel
-      services: docker
-      sudo: required
     -
       env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
       stage: static
@@ -89,8 +34,45 @@ matrix:
       rvm: 2.5.3
       stage: spec
     -
-      env: DEPLOY_TO_FORGE=yes
-      stage: deploy
+      before_script: ["bundle exec rake 'litmus:provision_list[travis_deb]'", "bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
+      bundler_args: 
+      dist: trusty
+      env: PLATFORMS=deb_puppet5
+      rvm: 2.5.3
+      script: ["bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+      sudo: required
+    -
+      before_script: ["bundle exec rake 'litmus:provision_list[travis_deb]'", "bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
+      bundler_args: 
+      dist: trusty
+      env: PLATFORM=centos:deb_puppet6
+      rvm: 2.5.3
+      script: ["bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+      sudo: required
+    -
+      before_script: ["bundle exec rake 'litmus:provision_list[travis_el]'", "bundle exec rake 'litmus:install_agent[puppet5]'", "bundle exec rake litmus:install_module"]
+      bundler_args: 
+      dist: trusty
+      env: PLATFORMS=el_puppet5
+      rvm: 2.5.3
+      script: ["bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+      sudo: required
+    -
+      before_script: ["bundle exec rake 'litmus:provision_list[travis_el]'", "bundle exec rake 'litmus:install_agent[puppet6]'", "bundle exec rake litmus:install_module"]
+      bundler_args: 
+      dist: trusty
+      env: PLATFORM=centos:el_puppet6
+      rvm: 2.5.3
+      script: ["bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+      sudo: required
 branches:
   only:
     - master
@@ -98,3 +80,12 @@ branches:
     - release
 notifications:
   email: false
+deploy:
+  provider: puppetforge
+  user: puppet
+  password:
+    secure: ""
+  on:
+    tags: true
+    all_branches: true
+    condition: "$DEPLOY_TO_FORGE = yes"

--- a/metadata.json
+++ b/metadata.json
@@ -59,7 +59,7 @@
       "version_requirement": ">=1.9.0"
     }
   ],
-  "pdk-version": "1.14.1",
+  "pdk-version": "1.15.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates/#master",
-  "template-ref": "heads/master-0-g643529a"
+  "template-ref": "heads/master-0-g73e79b9"
 }


### PR DESCRIPTION
See full description here: puppetlabs/pdk-templates#300

`.travis.yml` was unmanaged by the PDK, which I have now removed. Could do with a 2nd opinion from someone who knows more about this particular module as to why this was the case and whether or not there would be adverse effects from merging this