### PR TITLE
(maint) Update Puppet VS Code Extension ID

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "jpogran.puppet-vscode",
+    "puppet.puppet-vscode",
     "rebornix.Ruby"
   ]
 }


### PR DESCRIPTION
This commit updates the configuration file to point to the official Puppet VS Code Extension `puppet.puppet-vscode`
