### PR TITLE
(maint) drop unsupported operating systems

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,23 +14,13 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
     },
     {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "7",
-        "8",
-        "9"
-      ]
-    },
-    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -38,7 +28,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -46,8 +35,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
-        "16.04",
         "18.04"
       ]
     }


### PR DESCRIPTION
Dropped support for:
* EL 6
* Debian 7, 8, and 9
* Ubuntu 14.04, and 16.04