### PR TITLE
Update Debian, Ubuntu, and SLES support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,9 +33,25 @@
       ]
     },
     {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "12"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "10",
+        "11",
+        "12"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04"
+        "18.04",
+        "20.04",
+        "22.04"
       ]
     }
   ],


### PR DESCRIPTION
Adds support for:
* Debian 10, 11, and 12
* Ubuntu 20.04 and 22.04
* SLES 12