### PR TITLE
Revert "(ITHELP-87329) - replace pull_request_target with pull_request"

### DIFF
--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -7,7 +7,7 @@ on:
       - opened
       - labeled
       - unlabeled
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - labeled


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-hocon#122

We have discovered that this workflow does indeed need the `pull_request_target` event